### PR TITLE
Build fix

### DIFF
--- a/framework/vkdf-deps.hpp
+++ b/framework/vkdf-deps.hpp
@@ -21,6 +21,7 @@
 #include <GLFW/glfw3.h>
 
 // GLM
+#define GLM_ENABLE_EXPERIMENTAL
 #define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/gtc/matrix_transform.hpp>


### PR DESCRIPTION
The exact errors were:
```
/usr/include/glm/gtx/norm.hpp:21:3: error: #error "GLM: GLM_GTX_norm is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
 # error "GLM: GLM_GTX_norm is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
   ^~~~~
In file included from vkdf-deps.hpp:27:0,
                 from vkdf-util.hpp:4,
                 from vkdf-util.cpp:1:
/usr/include/glm/gtx/quaternion.hpp:23:3: error: #error "GLM: GLM_GTX_quaternion is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
 # error "GLM: GLM_GTX_quaternion is an experimental extension and may change in the future. Use #define GLM_ENABLE_EXPERIMENTAL before including it, if you really want to use it."
```