### PR TITLE
framework/scene: add gpointer cast

### DIFF
--- a/framework/vkdf-scene.cpp
+++ b/framework/vkdf-scene.cpp
@@ -2963,7 +2963,7 @@ create_shadow_map_pipeline_for_mesh(VkdfScene *s, VkdfMesh *mesh)
                                       NULL,
                                       &pipeline));
 
-   g_hash_table_insert(s->shadows.pipeline.pipelines, hash, pipeline);
+   g_hash_table_insert(s->shadows.pipeline.pipelines, hash, (gpointer) pipeline);
 }
 
 /**


### PR DESCRIPTION
Without it on raspbian we are getting the following build error
message:

vkdf-scene.cpp:2966:61: error: invalid conversion from 'VkPipeline' {aka 'long long unsigned int'} to 'gpointer' {aka 'void*'} [-fpermissive]
    g_hash_table_insert(s->shadows.pipeline.pipelines, hash, pipeline);

This doesn't happen on desktop. I guess that this is due different
versions of gcc, glib, and their default options.