### PR TITLE
Sdl wayland support

### DIFF
--- a/README
+++ b/README
@@ -91,4 +91,7 @@ generated shader files are re-generated again:
 $ make clean
 $ make -j
 
+Wayland support is only available via SDL
+
 Enjoy!
+

--- a/framework/vkdf-deps.hpp
+++ b/framework/vkdf-deps.hpp
@@ -21,6 +21,7 @@
 // Vulkan
 #ifdef VKDF_PLATFORM_SDL
 #define VK_USE_PLATFORM_XLIB_KHR
+#define VK_USE_PLATFORM_WAYLAND_KHR
 #endif
 #include <vulkan/vulkan.h>
 

--- a/framework/vkdf-platform-sdl.cpp
+++ b/framework/vkdf-platform-sdl.cpp
@@ -20,7 +20,7 @@ static void
 platform_init(VkdfPlatform *platform)
 {
    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0)
-      vkdf_fatal("Failed to initialize SDL2 platform");
+      vkdf_fatal("Failed to initialize SDL2 platform SDL_Error:%s", SDL_GetError());
 
    if (SDL_NumJoysticks() > 0) {
       SDL_Joystick *joy = SDL_JoystickOpen(0);
@@ -55,12 +55,13 @@ vkdf_platform_create_window(VkdfPlatform *platform,
                        fullscreen ? SDL_WINDOW_FULLSCREEN : 0 |
                        resizable  ? SDL_WINDOW_RESIZABLE  : 0);
 
+   if (!platform->window)
+      vkdf_fatal("Failed to create window: %s", SDL_GetError());
+
    platform->sdl.renderer =
       SDL_CreateRenderer(platform->window, -1, SDL_RENDERER_ACCELERATED);
 
 
-   if (!platform->window)
-      vkdf_fatal("Failed to create window");
 
    /* Specially in fullscreen mode, the size of the window may change a few
     * times before it gets to its final size. This means that it can take


### PR DESCRIPTION
Two first commits are just utility/misc, but the other two get the sponza working on full wayland environments.

The easier way to test them on a environment with X, XWayland, etc is using the following envvar:

`export SDL_VIDEODRIVER=wayland`

I'm not fully happy with the last commit, so this Pull request would work as a discussion thread too.