### PR TITLE
framework/demos: use VK_WHOLE_SIZE in vkdf_memory_map/unmap calls

### DIFF
--- a/demos/cpu-particle-source/main.cpp
+++ b/demos/cpu-particle-source/main.cpp
@@ -332,8 +332,7 @@ scene_update(VkdfContext *ctx, void *data)
 
    // Prepare particle UBO for rendering
    unsigned char *map;
-   VkDeviceSize ubo_size = sizeof(ParticleCollectionShaderData);
-   vkdf_memory_map(ctx, res->psr_ubo.mem, 0, ubo_size, (void **) &map);
+   vkdf_memory_map(ctx, res->psr_ubo.mem, 0, VK_WHOLE_SIZE, (void **) &map);
    glm::mat4 psr_vp = res->clip * res->projection * res->view;
    memcpy(map, &psr_vp, sizeof(glm::mat4));
    map += sizeof(glm::mat4);
@@ -349,7 +348,7 @@ scene_update(VkdfContext *ctx, void *data)
       iter = g_list_next(iter);
       map += sizeof(ParticleShaderData);
    }
-   vkdf_memory_unmap(ctx, res->psr_ubo.mem, res->psr_ubo.mem_props, 0, ubo_size);
+   vkdf_memory_unmap(ctx, res->psr_ubo.mem, res->psr_ubo.mem_props, 0, VK_WHOLE_SIZE);
 }
 
 static void

--- a/demos/model/main.cpp
+++ b/demos/model/main.cpp
@@ -316,7 +316,7 @@ init_objects(VkdfContext *ctx, DemoResources *res)
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
    uint32_t *map;
-   vkdf_memory_map(ctx, res->instance_buf.mem, 0, instance_data_size,
+   vkdf_memory_map(ctx, res->instance_buf.mem, 0, VK_WHOLE_SIZE,
                    (void **) &map);
 
    for (uint32_t j = 0; j < model->meshes.size(); j++) {
@@ -329,7 +329,7 @@ init_objects(VkdfContext *ctx, DemoResources *res)
    }
 
    vkdf_memory_unmap(ctx, res->instance_buf.mem, res->instance_buf.mem_props,
-                     0, instance_data_size);
+                     0, VK_WHOLE_SIZE);
 }
 
 static void

--- a/demos/pbr/main.cpp
+++ b/demos/pbr/main.cpp
@@ -664,7 +664,7 @@ init_objects(VkdfContext *ctx, DemoResources *res)
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
    uint32_t *map;
-   vkdf_memory_map(ctx, res->instance_buf.mem, 0, instance_data_size,
+   vkdf_memory_map(ctx, res->instance_buf.mem, 0, VK_WHOLE_SIZE,
                    (void **) &map);
 
    for (uint32_t j = 0; j < model->meshes.size(); j++) {
@@ -677,7 +677,7 @@ init_objects(VkdfContext *ctx, DemoResources *res)
    }
 
    vkdf_memory_unmap(ctx, res->instance_buf.mem, res->instance_buf.mem_props,
-                     0, instance_data_size);
+                     0, VK_WHOLE_SIZE);
 }
 
 static void

--- a/framework/vkdf-buffer.cpp
+++ b/framework/vkdf-buffer.cpp
@@ -54,12 +54,12 @@ vkdf_buffer_map_and_fill(VkdfContext *ctx,
    assert(buf.mem_props & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
    void *mapped_memory;
-   vkdf_memory_map(ctx, buf.mem, offset, size, &mapped_memory);
+   vkdf_memory_map(ctx, buf.mem, offset, VK_WHOLE_SIZE, &mapped_memory);
 
-   assert(buf.mem_reqs.size >= size);
+   assert(buf.mem_reqs.size >= offset + size);
    memcpy(mapped_memory, data, size);
 
-   vkdf_memory_unmap(ctx, buf.mem, buf.mem_props, offset, size);
+   vkdf_memory_unmap(ctx, buf.mem, buf.mem_props, offset, VK_WHOLE_SIZE);
 }
 
 void
@@ -77,9 +77,9 @@ vkdf_buffer_map_and_fill_elements(VkdfContext *ctx,
 
    void *mapped_memory;
    VkDeviceSize size = num_elements * dst_stride;
-   assert(buf.mem_reqs.size >= size);
+   assert(buf.mem_reqs.size >= offset + size);
 
-   vkdf_memory_map(ctx, buf.mem, offset, size, &mapped_memory);
+   vkdf_memory_map(ctx, buf.mem, offset, VK_WHOLE_SIZE, &mapped_memory);
 
    VkDeviceSize dst_offset = 0;
    VkDeviceSize src_offset = 0;
@@ -90,7 +90,7 @@ vkdf_buffer_map_and_fill_elements(VkdfContext *ctx,
       src_offset += src_stride;
    }
 
-   vkdf_memory_unmap(ctx, buf.mem, buf.mem_props, offset, size);
+   vkdf_memory_unmap(ctx, buf.mem, buf.mem_props, offset, VK_WHOLE_SIZE);
 }
 
 void

--- a/framework/vkdf-mesh.cpp
+++ b/framework/vkdf-mesh.cpp
@@ -317,7 +317,7 @@ vkdf_mesh_fill_vertex_buffer(VkdfContext *ctx, VkdfMesh *mesh)
 
    uint8_t *map;
    vkdf_memory_map(ctx, mesh->vertex_buf.mem,
-                   0, vertex_data_size, (void **) &map);
+                   0, VK_WHOLE_SIZE, (void **) &map);
 
    for (uint32_t i = 0; i < mesh->vertices.size(); i++) {
       uint32_t elem_size = sizeof(mesh->vertices[0]);
@@ -356,7 +356,7 @@ vkdf_mesh_fill_vertex_buffer(VkdfContext *ctx, VkdfMesh *mesh)
    }
 
    vkdf_memory_unmap(ctx, mesh->vertex_buf.mem, mesh->vertex_buf.mem_props,
-                     0, vertex_data_size);
+                     0, VK_WHOLE_SIZE);
 }
 
 static inline VkDeviceSize
@@ -393,12 +393,12 @@ vkdf_mesh_fill_index_buffer(VkdfContext *ctx, VkdfMesh *mesh)
 
    uint8_t *map;
    vkdf_memory_map(ctx, mesh->index_buf.mem,
-                   0, index_data_size, (void **) &map);
+                   0, VK_WHOLE_SIZE, (void **) &map);
 
    memcpy(map, &mesh->indices[0], index_data_size);
 
    vkdf_memory_unmap(ctx, mesh->index_buf.mem, mesh->index_buf.mem_props,
-                     0, index_data_size);
+                     0, VK_WHOLE_SIZE);
 }
 
 void

--- a/framework/vkdf-model.cpp
+++ b/framework/vkdf-model.cpp
@@ -422,7 +422,7 @@ model_fill_vertex_buffer(VkdfContext *ctx, VkdfModel *model)
 
    uint8_t *map;
    vkdf_memory_map(ctx, model->vertex_buf.mem,
-                   0, vertex_data_size, (void **) &map);
+                   0, VK_WHOLE_SIZE, (void **) &map);
 
    // Interleaved per-vertex attributes (position, normal, uv, material)
    VkDeviceSize byte_offset = 0;
@@ -460,7 +460,7 @@ model_fill_vertex_buffer(VkdfContext *ctx, VkdfModel *model)
    }
 
    vkdf_memory_unmap(ctx, model->vertex_buf.mem,
-                     model->vertex_buf.mem_props, 0, vertex_data_size);
+                     model->vertex_buf.mem_props, 0, VK_WHOLE_SIZE);
 }
 
 static void
@@ -486,7 +486,7 @@ model_fill_index_buffer(VkdfContext *ctx, VkdfModel *model)
 
    uint8_t *map;
    vkdf_memory_map(ctx, model->index_buf.mem,
-                   0, index_data_size, (void **) &map);
+                   0, VK_WHOLE_SIZE, (void **) &map);
 
    VkDeviceSize byte_offset = 0;
    for (uint32_t m = 0; m < model->meshes.size(); m++) {
@@ -500,7 +500,7 @@ model_fill_index_buffer(VkdfContext *ctx, VkdfModel *model)
    }
 
    vkdf_memory_unmap(ctx, model->index_buf.mem, model->index_buf.mem_props,
-                     0, index_data_size);
+                     0, VK_WHOLE_SIZE);
 }
 
 /**


### PR DESCRIPTION
We were getting the following Vulkan Validation layer warning with both v3dv and panvk:

Validation Error: [ VUID-VkMappedMemoryRange-size-01390 ] | MessageID = 0xdd4e6d8b vkFlushMappedMemoryRanges(): pMemoryRanges[0].size (924) is not a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize (64) The offset (0) + size (924) ends at 924 which is also not valid because it doesn't reach the end of the memory allocation size (960). The Vulkan spec states: If size is not equal to VK_WHOLE_SIZE, size must either be a multiple of VkPhysicalDeviceLimits::nonCoherentAtomSize, or offset plus size must equal the size of memo\ ry (https://docs.vulkan.org/spec/latest/chapters/memory.html#VUID-VkMappedMemoryRange-size-01390) Objects: 1
    [0] VkDeviceMemory 0x230000000023

Initially detected with sponza, but happened with other demos.

This was happening on the call of vkdf_memory_unmap as part of vkdf_mesh_fill_vertex_buffer. In addition to call VkUnmapMemory, for drivers not supporting VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, vkdf_memory_unmap calls vkFlushMappedMemoryRanges that is the call with the restriction detected by the Validation Layer.

This patch implements the straightforward solution to use VK_WHOLE_SIZE for all those cases, instead of going fine-grained to map/unmap exactly the bytes requires. VK_WHOLE_SIZE is exempt from the alignment rule and is the correct value when the entire buffer is mapped from offset 0, as is the case in all these call sites.

Also tighten the size assertion in both helpers to check offset + size <= mem_reqs.size rather than size alone.